### PR TITLE
Actually specify Java SE 8 in the classpath (mea culpa)

### DIFF
--- a/NightgamesMod/.classpath
+++ b/NightgamesMod/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path=""/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<accessrules>
+			<accessrule kind="discouraged" pattern="sun.reflect.generics.reflectiveObjects.NotImplementedException"/>
+		</accessrules>
+	</classpathentry>
 	<classpathentry kind="lib" path="js.jar"/>
 	<classpathentry kind="lib" path="gson-2.7.jar"/>
 	<classpathentry kind="lib" path="commons-lang3-3.5.jar"/>

--- a/NightgamesMod/nightgames/pet/PetCharacter.java
+++ b/NightgamesMod/nightgames/pet/PetCharacter.java
@@ -18,7 +18,6 @@ import nightgames.skills.Tactics;
 import nightgames.status.Slimed;
 import nightgames.status.Status;
 import nightgames.trap.Trap;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -140,7 +139,7 @@ public class PetCharacter extends Character {
 
     @Override public void doAction(Action action) {
         System.err.println(String.format("Pet character %s with owner type %s should not exist outside of combat.", this.getName(), this.ownerType));
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
The "workplace default" setting (which the last PR uses) works in my case because Java 1.8 _is_ my workplace default, but it occurred to me that that's probably not a great idea.

Alas, setting it to "environment: Java 1.8" also makes it throw a fit about NotImplementedException() being deprecated, so I've gone and changed those to UnsupportedOperationException(). If this is a bad thing to do for some reason, I will freely admit that I probably haven't had the experience yet to know why.

My apologies if this is getting annoying - especially considering that I realized this either while or right after you were merging the previous one.